### PR TITLE
Issue/46 inline config

### DIFF
--- a/spec/cli/stablerc/StablercFile.spec.ts
+++ b/spec/cli/stablerc/StablercFile.spec.ts
@@ -236,6 +236,20 @@ describe("StablercFile.loadAll(filename: string, params: StablercFileLoadParams)
         },
       ],
       [
+        "spec/runners/.stablerc.yml",
+        {
+          filename: "spec/runners/.stablerc.yml",
+          document: {
+            extends: [],
+            include: [],
+            exclude: [],
+            plugins: undefined,
+            runners: ["isolate"],
+          },
+          plugins: false,
+        },
+      ],
+      [
         "spec/cli/.stablerc.yml",
         {
           filename: "spec/cli/.stablerc.yml",
@@ -257,7 +271,15 @@ describe("StablercFile.loadAll(filename: string, params: StablercFileLoadParams)
             extends: ["../.stablerc.yml"],
             include: [],
             exclude: [],
-            plugins: [["timing", { timeout: 500 }], ["rescue"]],
+            plugins: [
+              [
+                "timing",
+                {
+                  timeout: 500,
+                },
+              ],
+              ["rescue"],
+            ],
             runners: undefined,
           },
           plugins: false,
@@ -271,7 +293,14 @@ describe("StablercFile.loadAll(filename: string, params: StablercFileLoadParams)
             extends: ["../.stablerc.yml"],
             include: [],
             exclude: [],
-            plugins: [["fixture", { include: "./fixture/**/*" }]],
+            plugins: [
+              [
+                "fixture",
+                {
+                  include: "./fixture/**/*",
+                },
+              ],
+            ],
             runners: ["isolate", "headless chrome", "jsdom"],
           },
           plugins: false,

--- a/spec/runners/.stablerc.yml
+++ b/spec/runners/.stablerc.yml
@@ -1,0 +1,2 @@
+runners:
+- isolate

--- a/spec/runners/remote/Sock.spec.ts
+++ b/spec/runners/remote/Sock.spec.ts
@@ -1,0 +1,21 @@
+/// <stable runner="headless chrome" />
+/// <stable runner="jsdom" />
+import { expect } from "chai";
+import { Sock } from "../../../src/runners/remote/Sock";
+
+describe("Sock", () => {
+  let subject: Sock;
+
+  beforeEach(() => {
+    subject = new Sock("ws://example.com/ws");
+  });
+
+  it("should be an instance of WebSocket", () => {
+    expect(subject).to.be.instanceOf(WebSocket);
+  });
+
+  it("should close straightaway currently because there is no server and this is not an end to end test", () =>
+    new Promise(resolve => {
+      subject.addEventListener("close", resolve, { once: true });
+    }));
+});

--- a/src/cli/readTripleSlashDirectives.ts
+++ b/src/cli/readTripleSlashDirectives.ts
@@ -1,0 +1,31 @@
+import { createReadStream } from "fs";
+import { runnerDirectiveRegex } from "./tripleSlashDirectives";
+
+interface Directive {
+  runner?: string;
+}
+
+export async function* readTripleSlashDirectives(
+  file: string,
+): AsyncIterableIterator<Directive> {
+  const readStream = createReadStream(file, {
+    encoding: "utf8",
+    highWaterMark: 1024,
+  });
+
+  for await (const chunk of readStream) {
+    lines: for (const line of chunk.split("\n")) {
+      if (!line.startsWith("///") && line.trim() !== "") {
+        return;
+      }
+      const m = line.match(runnerDirectiveRegex);
+
+      if (m == null) {
+        continue lines;
+      }
+      const [, , , runner] = m;
+
+      yield { runner };
+    }
+  }
+}

--- a/src/cli/task/BundleTask/index.ts
+++ b/src/cli/task/BundleTask/index.ts
@@ -11,7 +11,7 @@ export class BundleTask implements Task {
   async run(params: BundleTaskParams) {
     const { [CliArgKey.BUNDLE_FILE]: outFile = "static/bundle.js" } = params;
     const configs = await stablercsForParams(params);
-    const bundles = Bundle.fromConfigs(configs, params);
+    const bundles = await Bundle.fromConfigs(configs, params);
 
     for (const [runner, bundle] of bundles) {
       const b = await bundle.rollup();

--- a/src/cli/task/RunTask/index.ts
+++ b/src/cli/task/RunTask/index.ts
@@ -18,7 +18,7 @@ export class RunTask implements Task {
       [CliArgKey.BUNDLE_FILE]: outFileParam,
       [CliArgKey.COVERAGE]: coverage,
     }: RunTaskParams = params;
-    const bundles = Bundle.fromConfigs(await stablercsForParams(params), {
+    const bundles = await Bundle.fromConfigs(await stablercsForParams(params), {
       ...params,
       [CliArgKey.ONREADY]: "stableRun",
     });

--- a/src/cli/tripleSlashDirectives.ts
+++ b/src/cli/tripleSlashDirectives.ts
@@ -1,0 +1,1 @@
+export const runnerDirectiveRegex = /^(\/\/\/\s*<stable\s+runner\s*=\s*)('|")(.+?)\2.*?\/>/;


### PR DESCRIPTION
Closes #46 

I went with what's behind "Door No. 2" for now. First example of a triple-slash directive is the runner for Sock.ts in the remote runner, which should run only in headless chrome and jsdom runners (since AFAIK, WebSocket isn't a global yet in node.js)